### PR TITLE
CIのstatus badgeを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # bmf-tech-client
-[![CircleCI](https://circleci.com/gh/bmf-san/bmf-tech-client/tree/master.svg?style=svg)](https://circleci.com/gh/bmf-san/bmf-tech-client/tree/master)
-
 # Dockerhub
 [bmfsan/bmf-tech-client](https://hub.docker.com/r/bmfsan/bmf-tech-client)
 


### PR DESCRIPTION
private repoだとバッチの画像が出ないんだった