### PR TITLE
Go1.18のサポート終了

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ workflows:
       - lint:
           matrix:
             parameters:
-              version: ["1.20", "1.19", "1.18"]
+              version: ["1.20", "1.19"]
       - test:
           matrix:
             parameters:
-              version: ["1.20", "1.19", "1.18"]
+              version: ["1.20", "1.19"]


### PR DESCRIPTION
# Overview
タイトルどおり。
そもそもlatestだけサポートで問題ないが、gobel-apiに合わせておく。

# Changes

# Impact range

# Operational Requirements

# Related Issue

# Supplement
