### PR TITLE
articleタグ内のhタグのfont-size指定を破棄

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -17,31 +17,26 @@
 
 .article h2 {
 	font-weight: bold;
-	font-size: x-large;
 	margin-top: 1.5em;
 }
 
 .article h3 {
 	font-weight: bold;
-	font-size: large;
 	margin-top: 1.5em;
 }
 
 .article h4 {
 	font-weight: bold;
-	font-size: medium;
 	margin-top: 1.5em;
 }
 
 .article h5 {
 	font-weight: bold;
-	font-size: small;
 	margin-top: 1.5em;
 }
 
 .article h6 {
 	font-weight: bold;
-	font-size: x-small;
 	margin-top: 1.5em;
 }
 


### PR DESCRIPTION
# Overview
管理画面のpreviewとfont-sizeずれていた。
font-size指定により、h3タグあたりからpタグとfont-sizeが同じになってしまっていた。

# Changes
articleタグ内のhタグのfont-size指定をやめた。

# Impact range

# Operational Requirements

# Related Issue

# Supplement
