### PR TITLE
ErrorページにisAdのテンプレート関数を用意していなかった

### DIFF
--- a/app/middleware/middleware.go
+++ b/app/middleware/middleware.go
@@ -30,7 +30,7 @@ func (mw *Middleware) Recovery(next http.Handler) http.Handler {
 			if err := recover(); err != nil {
 				switch e := err.(type) {
 				case string:
-					mw.logger.Error("[panic]" + e)
+					mw.logger.Error("[panic] " + e)
 				case runtime.Error:
 					mw.logger.Error("[panic] " + e.Error())
 				case error:

--- a/app/presenter/error.go
+++ b/app/presenter/error.go
@@ -22,6 +22,7 @@ func (p *Presenter) Error(w http.ResponseWriter, code int) {
 
 	fm := template.FuncMap{
 		"year": p.year,
+		"isAd": p.IsAd,
 	}
 	m := &model.Meta{
 		Title:   "bmf-tech.com - エラー",


### PR DESCRIPTION
# Overview
isAdのテンプレート関数がErrorページのpresenterにセットされていなかった。

# Changes
isAd関数をErrorページのpresenterに追加

# Impact range

# Operational Requirements

# Related Issue

# Supplement
本番環境の当該エラーログにも出てた