### PR TITLE
WriteHeaderの副作用を防止

### DIFF
--- a/app/controller/category_controller.go
+++ b/app/controller/category_controller.go
@@ -34,14 +34,20 @@ func (cc *CategoryController) Index() http.Handler {
 		page, _, err := cc.Client.GetPageAndLimit(r)
 		if err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		resp, err := cc.Client.GetCategories(page, 100)
 		if err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -49,7 +55,10 @@ func (cc *CategoryController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -57,14 +66,20 @@ func (cc *CategoryController) Index() http.Handler {
 
 		if err := json.Unmarshal(body, &categories); err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -76,7 +91,10 @@ func (cc *CategoryController) Index() http.Handler {
 			},
 		}); err != nil {
 			cc.Logger.Error(err.Error())
-			cc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := cc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				cc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/feed_controller.go
+++ b/app/controller/feed_controller.go
@@ -37,7 +37,10 @@ func (fc *FeedController) Index() http.Handler {
 		resp, err := fc.Client.GetPosts(1, 99999)
 		if err != nil {
 			fc.Logger.Error(err.Error())
-			fc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := fc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				fc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -45,7 +48,10 @@ func (fc *FeedController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			fc.Logger.Error(err.Error())
-			fc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := fc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				fc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -53,7 +59,10 @@ func (fc *FeedController) Index() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			fc.Logger.Error(err.Error())
-			fc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := fc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				fc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 

--- a/app/controller/home_controller.go
+++ b/app/controller/home_controller.go
@@ -34,14 +34,20 @@ func (hc *HomeController) Index() http.Handler {
 		page, limit, err := hc.Client.GetPageAndLimit(r)
 		if err != nil {
 			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := hc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				hc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		resp, err := hc.Client.GetPosts(page, limit)
 		if err != nil {
 			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := hc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				hc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -49,7 +55,10 @@ func (hc *HomeController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := hc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				hc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -57,7 +66,10 @@ func (hc *HomeController) Index() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := hc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				hc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -65,7 +77,10 @@ func (hc *HomeController) Index() http.Handler {
 			Posts: &posts,
 		}); err != nil {
 			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := hc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				hc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/post_controller.go
+++ b/app/controller/post_controller.go
@@ -38,14 +38,20 @@ func (pc *PostController) Index() http.Handler {
 		page, limit, err := pc.Client.GetPageAndLimit(r)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		resp, err := pc.Client.GetPosts(page, limit)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -53,7 +59,10 @@ func (pc *PostController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -61,14 +70,20 @@ func (pc *PostController) Index() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -80,7 +95,10 @@ func (pc *PostController) Index() http.Handler {
 			},
 		}); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})
@@ -92,7 +110,10 @@ func (pc *PostController) IndexByKeyword() http.Handler {
 		page, limit, err := pc.Client.GetPageAndLimit(r)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -100,7 +121,10 @@ func (pc *PostController) IndexByKeyword() http.Handler {
 		resp, err := pc.Client.GetPostsByKeyword(keyword, page, limit)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -108,7 +132,10 @@ func (pc *PostController) IndexByKeyword() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -116,14 +143,20 @@ func (pc *PostController) IndexByKeyword() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -136,7 +169,10 @@ func (pc *PostController) IndexByKeyword() http.Handler {
 			},
 		}); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})
@@ -148,7 +184,10 @@ func (pc *PostController) IndexByCategory() http.Handler {
 		page, limit, err := pc.Client.GetPageAndLimit(r)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -156,7 +195,10 @@ func (pc *PostController) IndexByCategory() http.Handler {
 		resp, err := pc.Client.GetPostsByCategory(name, page, limit)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -164,7 +206,10 @@ func (pc *PostController) IndexByCategory() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -172,14 +217,20 @@ func (pc *PostController) IndexByCategory() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -192,7 +243,10 @@ func (pc *PostController) IndexByCategory() http.Handler {
 			},
 		}); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})
@@ -204,7 +258,10 @@ func (pc *PostController) IndexByTag() http.Handler {
 		page, limit, err := pc.Client.GetPageAndLimit(r)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -212,7 +269,10 @@ func (pc *PostController) IndexByTag() http.Handler {
 		resp, err := pc.Client.GetPostsByTag(name, page, limit)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -220,7 +280,10 @@ func (pc *PostController) IndexByTag() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -228,14 +291,20 @@ func (pc *PostController) IndexByTag() http.Handler {
 
 		if err := json.Unmarshal(body, &posts); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -248,7 +317,10 @@ func (pc *PostController) IndexByTag() http.Handler {
 			},
 		}); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})
@@ -262,7 +334,10 @@ func (pc *PostController) Show() http.Handler {
 		resp, err := pc.Client.GetPost(title)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -270,7 +345,10 @@ func (pc *PostController) Show() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -278,7 +356,10 @@ func (pc *PostController) Show() http.Handler {
 
 		if err := json.Unmarshal(body, &post); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -287,7 +368,10 @@ func (pc *PostController) Show() http.Handler {
 			LinkSupport: os.Getenv("BASE_URL") + "/support",
 		}); err != nil {
 			pc.Logger.Error(err.Error())
-			pc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/privacy_policy_controller.go
+++ b/app/controller/privacy_policy_controller.go
@@ -23,11 +23,14 @@ func NewPrivacyPolicyController(logger *slog.Logger, presenter *presenter.Presen
 }
 
 // Index displays a listing of the resource.
-func (hc *PrivacyPolicyController) Index() http.Handler {
+func (pc *PrivacyPolicyController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := hc.Presenter.ExecutePrivacyPolicyIndex(w, r); err != nil {
-			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+		if err := pc.Presenter.ExecutePrivacyPolicyIndex(w, r); err != nil {
+			pc.Logger.Error(err.Error())
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/profile_controller.go
+++ b/app/controller/profile_controller.go
@@ -23,11 +23,14 @@ func NewProfileController(logger *slog.Logger, presenter *presenter.Presenter) *
 }
 
 // Index displays a listing of the resource.
-func (hc *ProfileController) Index() http.Handler {
+func (pc *ProfileController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := hc.Presenter.ExecuteProfileIndex(w, r); err != nil {
-			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+		if err := pc.Presenter.ExecuteProfileIndex(w, r); err != nil {
+			pc.Logger.Error(err.Error())
+			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				pc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/sitemapController.go
+++ b/app/controller/sitemapController.go
@@ -37,7 +37,10 @@ func (si *SitemapController) Index() http.Handler {
 		resp, err := si.Client.GetPosts(1, 99999)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -45,14 +48,20 @@ func (si *SitemapController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var posts model.Posts
 		if err = json.Unmarshal(body, &posts); err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -60,7 +69,10 @@ func (si *SitemapController) Index() http.Handler {
 		resp, err = si.Client.GetCategories(1, 99999)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -68,14 +80,20 @@ func (si *SitemapController) Index() http.Handler {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var categories model.Categories
 		if err = json.Unmarshal(body, &categories); err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -83,7 +101,10 @@ func (si *SitemapController) Index() http.Handler {
 		resp, err = si.Client.GetTags(1, 99999)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -91,14 +112,20 @@ func (si *SitemapController) Index() http.Handler {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var tags model.Tags
 		if err = json.Unmarshal(body, &tags); err != nil {
 			si.Logger.Error(err.Error())
-			si.Presenter.Error(w, http.StatusInternalServerError)
+			if err := si.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				si.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 

--- a/app/controller/support_controller.go
+++ b/app/controller/support_controller.go
@@ -23,11 +23,14 @@ func NewSupportController(logger *slog.Logger, presenter *presenter.Presenter) *
 }
 
 // Index displays a listing of the resource.
-func (hc *SupportController) Index() http.Handler {
+func (sc *SupportController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := hc.Presenter.ExecuteSupportIndex(w, r); err != nil {
-			hc.Logger.Error(err.Error())
-			hc.Presenter.Error(w, http.StatusInternalServerError)
+		if err := sc.Presenter.ExecuteSupportIndex(w, r); err != nil {
+			sc.Logger.Error(err.Error())
+			if err := sc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				sc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/controller/tag_controller.go
+++ b/app/controller/tag_controller.go
@@ -33,14 +33,20 @@ func (tc *TagController) Index() http.Handler {
 		page, _, err := tc.Client.GetPageAndLimit(r)
 		if err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		resp, err := tc.Client.GetTags(page, 100)
 		if err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 		defer resp.Body.Close()
@@ -48,7 +54,10 @@ func (tc *TagController) Index() http.Handler {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -56,14 +65,20 @@ func (tc *TagController) Index() http.Handler {
 
 		if err := json.Unmarshal(body, &tags); err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
 		var pagination model.Pagination
 		if err := pagination.Convert(resp.Header); err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 
@@ -75,7 +90,10 @@ func (tc *TagController) Index() http.Handler {
 			},
 		}); err != nil {
 			tc.Logger.Error(err.Error())
-			tc.Presenter.Error(w, http.StatusInternalServerError)
+			if err := tc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+				tc.Logger.Error(err.Error())
+				w.Write([]byte(err.Error()))
+			}
 			return
 		}
 	})

--- a/app/middleware/middleware.go
+++ b/app/middleware/middleware.go
@@ -39,7 +39,10 @@ func (mw *Middleware) Recovery(next http.Handler) http.Handler {
 				default:
 					mw.logger.Error("[panic] " + e.(string))
 				}
-				mw.presenter.Error(w, http.StatusInternalServerError)
+				if err := mw.presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+					mw.logger.Error(err.Error())
+					w.Write([]byte(err.Error()))
+				}
 				return
 			}
 		}()


### PR DESCRIPTION
# Overview
WriteHeaderの副作用で、Headerのセットが一部のリクエストで（特定できていない）余計にされていたエラーを改善。

# Changes
bytes.Bufferを用意し、ResponseWriterを調整。

# Impact range

# Operational Requirements

# Related Issue
https://github.com/bmf-san/bmf-tech-client/issues/72

# Supplement
