### PR TITLE
レスポンス周りのbytes.Bufferの使い方を見直した

### DIFF
--- a/app/controller/controller.go
+++ b/app/controller/controller.go
@@ -1,0 +1,16 @@
+package controller
+
+import (
+	"bytes"
+	"net/http"
+)
+
+func bufWriteTo(buf *bytes.Buffer, w http.ResponseWriter, code int) {
+	w.WriteHeader(code)
+	if buf == nil {
+		w.Write([]byte("Response Error"))
+	}
+	if _, err := buf.WriteTo(w); err != nil {
+		w.Write([]byte(err.Error()))
+	}
+}

--- a/app/controller/privacy_policy_controller.go
+++ b/app/controller/privacy_policy_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"net/http"
 
 	"log/slog"
@@ -25,13 +26,18 @@ func NewPrivacyPolicyController(logger *slog.Logger, presenter *presenter.Presen
 // Index displays a listing of the resource.
 func (pc *PrivacyPolicyController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := pc.Presenter.ExecutePrivacyPolicyIndex(w, r); err != nil {
+		buf := new(bytes.Buffer)
+		code := http.StatusOK
+		buf, err := pc.Presenter.ExecutePrivacyPolicyIndex(buf, r)
+		if err != nil {
 			pc.Logger.Error(err.Error())
-			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+			code = http.StatusInternalServerError
+			buf, err = pc.Presenter.ExecuteError(buf, http.StatusInternalServerError)
+			if err != nil {
 				pc.Logger.Error(err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			return
 		}
+
+		bufWriteTo(buf, w, code)
 	})
 }

--- a/app/controller/profile_controller.go
+++ b/app/controller/profile_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"net/http"
 
 	"log/slog"
@@ -25,13 +26,17 @@ func NewProfileController(logger *slog.Logger, presenter *presenter.Presenter) *
 // Index displays a listing of the resource.
 func (pc *ProfileController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := pc.Presenter.ExecuteProfileIndex(w, r); err != nil {
+		buf := new(bytes.Buffer)
+		code := http.StatusOK
+		buf, err := pc.Presenter.ExecuteProfileIndex(buf, r)
+		if err != nil {
 			pc.Logger.Error(err.Error())
-			if err := pc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+			code = http.StatusInternalServerError
+			buf, err = pc.Presenter.ExecuteError(buf, code)
+			if err != nil {
 				pc.Logger.Error(err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			return
 		}
+		bufWriteTo(buf, w, code)
 	})
 }

--- a/app/controller/support_controller.go
+++ b/app/controller/support_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"net/http"
 
 	"log/slog"
@@ -25,13 +26,18 @@ func NewSupportController(logger *slog.Logger, presenter *presenter.Presenter) *
 // Index displays a listing of the resource.
 func (sc *SupportController) Index() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := sc.Presenter.ExecuteSupportIndex(w, r); err != nil {
+		buf := new(bytes.Buffer)
+		code := http.StatusOK
+		buf, err := sc.Presenter.ExecuteSupportIndex(buf, r)
+		if err != nil {
 			sc.Logger.Error(err.Error())
-			if err := sc.Presenter.ExecuteError(w, http.StatusInternalServerError); err != nil {
+			code = http.StatusInternalServerError
+			buf, err = sc.Presenter.ExecuteError(buf, code)
+			if err != nil {
 				sc.Logger.Error(err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			return
 		}
+
+		bufWriteTo(buf, w, code)
 	})
 }

--- a/app/presenter/category.go
+++ b/app/presenter/category.go
@@ -16,7 +16,7 @@ type CategoryIndex struct {
 }
 
 // ExecuteCategoryIndex responses a index template.
-func (p *Presenter) ExecuteCategoryIndex(w http.ResponseWriter, r *http.Request, c *CategoryIndex) error {
+func (p *Presenter) ExecuteCategoryIndex(buf *bytes.Buffer, r *http.Request, c *CategoryIndex) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year": p.year,
 		"isAd": p.IsAd,
@@ -38,19 +38,10 @@ func (p *Presenter) ExecuteCategoryIndex(w http.ResponseWriter, r *http.Request,
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(p.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/category/index.tpl", "templates/partial/pagination.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Categories": c}); err != nil {
-		if err := p.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Categories": c}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/error.go
+++ b/app/presenter/error.go
@@ -1,8 +1,8 @@
 package presenter
 
 import (
+	"bytes"
 	"html/template"
-	"net/http"
 
 	"github.com/bmf-san/bmf-tech-client/app/model"
 )
@@ -14,10 +14,10 @@ type ErrorData struct {
 }
 
 // ExecuteError responses a error template.
-func (p *Presenter) ExecuteError(w http.ResponseWriter, code int) error {
+func (p *Presenter) ExecuteError(buf *bytes.Buffer, code int) (*bytes.Buffer, error) {
 	e := &ErrorData{
 		Code:    code,
-		Message: handleErrorMessage(code),
+		Message: "すみません！エラーです！",
 	}
 	fm := template.FuncMap{
 		"year": p.year,
@@ -28,21 +28,9 @@ func (p *Presenter) ExecuteError(w http.ResponseWriter, code int) error {
 		NoIndex: true,
 	}
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(p.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/error/index.tpl"))
-
-	w.WriteHeader(e.Code)
-
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "ErrorData": e}); err != nil {
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "ErrorData": e}); err != nil {
+		return nil, err
 	}
 
-	return nil
-}
-
-// handleErrorMessage handles an error message by code.
-func handleErrorMessage(code int) string {
-	switch code {
-	case http.StatusInternalServerError:
-		return "すみません！エラーです！"
-	}
-	return ""
+	return buf, nil
 }

--- a/app/presenter/home.go
+++ b/app/presenter/home.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ExecuteHomeIndex responses a index template.
-func (pt *Presenter) ExecuteHomeIndex(w http.ResponseWriter, r *http.Request, p *PostIndex) error {
+func (pt *Presenter) ExecuteHomeIndex(buf *bytes.Buffer, r *http.Request, p *PostIndex) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":      pt.year,
 		"striptags": pt.StripTags,
@@ -34,19 +34,10 @@ func (pt *Presenter) ExecuteHomeIndex(w http.ResponseWriter, r *http.Request, p 
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/home/index.tpl", "templates/partial/posts.tpl", "templates/partial/search.tpl"))
-	if err := tpl.ExecuteTemplate(&buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/post.go
+++ b/app/presenter/post.go
@@ -43,7 +43,7 @@ type PostShow struct {
 }
 
 // ExecutePostIndex responses a index template.
-func (pt *Presenter) ExecutePostIndex(w http.ResponseWriter, r *http.Request, p *PostIndex) error {
+func (pt *Presenter) ExecutePostIndex(buf *bytes.Buffer, r *http.Request, p *PostIndex) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":      pt.year,
 		"striptags": pt.StripTags,
@@ -66,15 +66,17 @@ func (pt *Presenter) ExecutePostIndex(w http.ResponseWriter, r *http.Request, p 
 		TwitterSite:   "@bmf_san",
 		NoIndex:       false,
 	}
+
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/post/index.tpl", "templates/partial/pagination.tpl", "templates/partial/posts.tpl", "templates/partial/search.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
+		return nil, err
 	}
-	return nil
+
+	return buf, nil
 }
 
 // ExecutePostIndexByKeyword responses a index template by keyword.
-func (pt *Presenter) ExecutePostIndexByKeyword(w http.ResponseWriter, r *http.Request, p *PostIndexBySearch) error {
+func (pt *Presenter) ExecutePostIndexByKeyword(buf *bytes.Buffer, r *http.Request, p *PostIndexBySearch) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":      pt.year,
 		"striptags": pt.StripTags,
@@ -98,25 +100,16 @@ func (pt *Presenter) ExecutePostIndexByKeyword(w http.ResponseWriter, r *http.Re
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/post/search.tpl", "templates/partial/pagination.tpl", "templates/partial/posts.tpl", "templates/partial/search.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }
 
 // ExecutePostIndexByCategory responses a index template by category.
-func (pt *Presenter) ExecutePostIndexByCategory(w http.ResponseWriter, r *http.Request, p *PostIndexByCategory) error {
+func (pt *Presenter) ExecutePostIndexByCategory(buf *bytes.Buffer, r *http.Request, p *PostIndexByCategory) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":      pt.year,
 		"striptags": pt.StripTags,
@@ -140,25 +133,16 @@ func (pt *Presenter) ExecutePostIndexByCategory(w http.ResponseWriter, r *http.R
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/post/category.tpl", "templates/partial/pagination.tpl", "templates/partial/posts.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }
 
 // ExecutePostIndexByTag responses a index template by tag.
-func (pt *Presenter) ExecutePostIndexByTag(w http.ResponseWriter, r *http.Request, p *PostIndexByTag) error {
+func (pt *Presenter) ExecutePostIndexByTag(buf *bytes.Buffer, r *http.Request, p *PostIndexByTag) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":      pt.year,
 		"striptags": pt.StripTags,
@@ -182,25 +166,16 @@ func (pt *Presenter) ExecutePostIndexByTag(w http.ResponseWriter, r *http.Reques
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/post/tag.tpl", "templates/partial/pagination.tpl", "templates/partial/posts.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Posts": p}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }
 
 // ExecutePostShow responses a show template by tag.
-func (pt *Presenter) ExecutePostShow(w http.ResponseWriter, r *http.Request, p *PostShow) error {
+func (pt *Presenter) ExecutePostShow(buf *bytes.Buffer, r *http.Request, p *PostShow) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year":     pt.year,
 		"unescape": pt.Unescape,
@@ -224,19 +199,10 @@ func (pt *Presenter) ExecutePostShow(w http.ResponseWriter, r *http.Request, p *
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/post/show.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Post": p}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Post": p}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/privacy_policy.go
+++ b/app/presenter/privacy_policy.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ExecutePrivacyPolicyIndex responses a index template.
-func (pt *Presenter) ExecutePrivacyPolicyIndex(w http.ResponseWriter, r *http.Request) error {
+func (pt *Presenter) ExecutePrivacyPolicyIndex(buf *bytes.Buffer, r *http.Request) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year": pt.year,
 		"isAd": pt.IsAd,
@@ -32,19 +32,10 @@ func (pt *Presenter) ExecutePrivacyPolicyIndex(w http.ResponseWriter, r *http.Re
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/privacy_policy/index.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/profile.go
+++ b/app/presenter/profile.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ExecuteProfileIndex responses a index template.
-func (pt *Presenter) ExecuteProfileIndex(w http.ResponseWriter, r *http.Request) error {
+func (pt *Presenter) ExecuteProfileIndex(buf *bytes.Buffer, r *http.Request) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year": pt.year,
 		"isAd": pt.IsAd,
@@ -32,19 +32,10 @@ func (pt *Presenter) ExecuteProfileIndex(w http.ResponseWriter, r *http.Request)
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/profile/index.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/support.go
+++ b/app/presenter/support.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ExecuteSupportIndex responses a index template.
-func (pt *Presenter) ExecuteSupportIndex(w http.ResponseWriter, r *http.Request) error {
+func (pt *Presenter) ExecuteSupportIndex(buf *bytes.Buffer, r *http.Request) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year": pt.year,
 		"isAd": pt.IsAd,
@@ -32,19 +32,10 @@ func (pt *Presenter) ExecuteSupportIndex(w http.ResponseWriter, r *http.Request)
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(pt.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/support/index.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m}); err != nil {
-		if err := pt.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }

--- a/app/presenter/tag.go
+++ b/app/presenter/tag.go
@@ -16,7 +16,7 @@ type TagIndex struct {
 }
 
 // ExecuteTagIndex responses a index template.
-func (p *Presenter) ExecuteTagIndex(w http.ResponseWriter, r *http.Request, t *TagIndex) error {
+func (p *Presenter) ExecuteTagIndex(buf *bytes.Buffer, r *http.Request, t *TagIndex) (*bytes.Buffer, error) {
 	fm := template.FuncMap{
 		"year": p.year,
 		"isAd": p.IsAd,
@@ -38,19 +38,10 @@ func (p *Presenter) ExecuteTagIndex(w http.ResponseWriter, r *http.Request, t *T
 		NoIndex:       false,
 	}
 
-	var buf bytes.Buffer
-
 	tpl := template.Must(template.New("base").Funcs(fm).ParseFS(p.templates, "templates/layout/base.tpl", "templates/partial/meta.tpl", "templates/tag/index.tpl", "templates/partial/pagination.tpl"))
-	if err := tpl.ExecuteTemplate(w, "base", map[string]interface{}{"Meta": m, "Tags": t}); err != nil {
-		if err := p.ExecuteError(w, http.StatusInternalServerError); err != nil {
-			return err
-		}
-		return err
+	if err := tpl.ExecuteTemplate(buf, "base", map[string]interface{}{"Meta": m, "Tags": t}); err != nil {
+		return nil, err
 	}
 
-	if _, err := buf.WriteTo(w); err != nil {
-		return err
-	}
-
-	return nil
+	return buf, nil
 }


### PR DESCRIPTION
# Overview
以下PRでReponse Headerのsuperflousエラーを解決したつもりだったが、まだ発生する箇所があった。

https://github.com/bmf-san/bmf-tech-client/pull/75
https://github.com/bmf-san/bmf-tech-client/pull/77

# Changes
- レスポンスのデータはbytes.Bufferを用意して、Bufferに書き込む形を徹底した。
- ExectuteXXXの責務を見直した（tplのExecuteしかしないようにした。）

# Impact range

# Operational Requirements

# Related Issue

# Supplement
